### PR TITLE
feat: transparent bars and more discrete tab stacks

### DIFF
--- a/css/main_arc.css
+++ b/css/main_arc.css
@@ -1,6 +1,6 @@
-/*update:2023.07.23*/
+/*update:2023.07.31*/
 
-/* transparent&narrow header*/
+/*transparent&narrow header*/
 #browser:not(.address-top) > #header,
 .color-behind-tabs-off:not(.is-settingspage)#browser:not(.tabs-top):not(.tabs-bottom) #header
 {
@@ -20,6 +20,10 @@
 
 /*address bar*/
 
+.UrlBar-SearchField, .UrlBar-AddressField, .SearchField {
+    background-color: rgba(var(--colorBg), 0.1);
+}
+
 .color-behind-tabs-off.address-top#browser:not(.tabs-top):not(.tabs-bottom) .mainbar{
     background:transparent;
     border:none;
@@ -28,7 +32,6 @@
 #browser.mac.address-top .toolbar:has(.window-buttongroup.on-mainbar){
     padding: 0 calc(8px / var(--uiZoomLevel));
     min-height: calc(40px / var(--uiZoomLevel));
-    
 }
 
 #browser:not(.tabs-top):not(.tabs-bottom).color-behind-tabs-off .toolbar-mainbar .toolbar-extensions, 
@@ -241,8 +244,19 @@
 #browser:not(.tabs-top):not(.tabs-bottom):not(.fullscreen) .mosaic-split .mosaic-split-line,
 #browser:not(.tabs-top):not(.tabs-bottom):not(.fullscreen) .mosaic-split .mosaic-split-line:before, .mosaic-split .mosaic-split-line:after{
     background:transparent;
-} 
+}
 
+/*tab stack frame*/
+.dim-blurred:not(.hasfocus) .svg-tab-stack, .dim-blurred:not(.hasfocus) .stack-frame {
+    stroke: var(--colorBorder);
+}
+.svg-tab-stack, .stack-frame {
+    stroke: var(--colorBgIntense);
+}
+.svg-tab-stack line, .svg-tab-selection line, .svg-tab-stack rect, .svg-tab-selection rect {
+    fill: none;
+    stroke-width: 1px;
+}
 
 /*webview-container*/
 


### PR DESCRIPTION
Hi!

Here I come with a very small update which:
- makes address bars with semi-transparent background so that it feels more integrated,
- I changed the stacked tabs stroke width and color so that it matches the new address bar better. I think it's more discrete this way. Previously it was using colorAccent as stroke, but with a gradient background it may seem odd. Using the more neural colorBg or colorBorder looked better to me.

![Screenshot from 2023-07-31 11:14:23](https://github.com/tovifun/VivalArc/assets/10899984/da5b5080-45c4-4143-adca-05af664c0e33)

What do you think about it?